### PR TITLE
Handle netaddr.core.NotRegisteredError with "Not Registered" vendor.

### DIFF
--- a/bin/maclookup.py
+++ b/bin/maclookup.py
@@ -142,8 +142,12 @@ for line in results:
                 logger.info( 'and put it into new list, so more dict can be added ...' )
                 list.append(line)
                 logger.info( 'new list : %s ' % list)
+            except netaddr.core.NotRegisteredError:
+                line['vendor'] = "Not Registered"
+                list.append(line)
             except:
-                logger.error( 'failed to use the netaddr module!' )
+                e = sys.exc_info()[0]
+                logger.error( "failed to use the netaddr module! %s" % e )
                 splunk.Intersplunk.generateErrorResults(': failed to use the netaddr module!')
                 exit()
 


### PR DESCRIPTION
This adds additional exception catching for the netaddr.core.NotRegisteredError.

All it does in that case is set vendor="Not Registered"

I also opportunistically added a little more detail to the failure case logging.

This should address issues mentioned in:
* https://answers.splunk.com/answers/702830/can-another-mac-addr-lookup-source-be-used.html
* https://answers.splunk.com/answers/773347/error-on-maclookup-command-netaddr-not-found.html